### PR TITLE
Don't parse the json again after tska fetch

### DIFF
--- a/utils/Prices.js
+++ b/utils/Prices.js
@@ -109,7 +109,7 @@ export default class Prices {
             },
             json: true
         }).then(function(res) {
-                let tempBzPrices = JSON.parse(res);
+                let tempBzPrices = res;
                 let realBzPrices = {
                     lastUpdated: tempBzPrices.lastUpdated
                 };
@@ -131,7 +131,7 @@ export default class Prices {
             },
             json: true
         }).then(function(res) {
-                Prices.priceData.ahPrices = JSON.parse(res);
+                Prices.priceData.ahPrices = res;
                 Prices.priceData.ahLastUpdated = Date.now();
                 Prices.priceData.save();
                 Prices.sentAH = false;


### PR DESCRIPTION
When using the `tska` fetch, you are using the json flag, which parses the response into a JSON object.
Therefor, you don't need to parse it again. 

Btw, I really like the aesthetic of the croesus overlay. Great work. And please stream more :)